### PR TITLE
Fix build inconsistencies

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -35,4 +35,4 @@ else
     end), zstd)
 end
 
-@BinDeps.install Dict(:libzstd => :libzstd)
+@BinDeps.install Dict(:zstd => :libzstd)

--- a/src/ZStd.jl
+++ b/src/ZStd.jl
@@ -19,9 +19,9 @@ Base.showerror(io::IO, ex::ZStdError) = print(io, "ZStd: " * ex.msg)
 
 # Determine whether the input represents a zstd error, yes => throw it, no => return it
 function check_zstd_error(code::Csize_t)
-    iserr = Bool(ccall((:ZSTD_isError, :libzstd), Cuint, (Csize_t, ), code))
+    iserr = Bool(ccall((:ZSTD_isError, libzstd), Cuint, (Csize_t, ), code))
     if iserr
-        msg = unsafe_string(ccall((:ZSTD_getErrorName, :libzstd), Ptr{Cchar}, (Csize_t, ), code))
+        msg = unsafe_string(ccall((:ZSTD_getErrorName, libzstd), Ptr{Cchar}, (Csize_t, ), code))
         throw(ZStdError(msg))
     end
     return code # input is not an error
@@ -33,7 +33,7 @@ end
 
 An integer representing the maximum compression level available.
 """
-const MAX_COMPRESSION = Int(ccall((:ZSTD_maxCLevel, :libzstd), Cint, ()))
+const MAX_COMPRESSION = Int(ccall((:ZSTD_maxCLevel, libzstd), Cint, ()))
 
 
 end # module


### PR DESCRIPTION
We need to map the `library_dependency` `zstd` to the variable name `libzstd`, then we need to use that variable name in our `ccall` invocations.
